### PR TITLE
add lower and upper case formatting

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -14,7 +14,10 @@ func BenchmarkFormatSize(b *testing.B) {
 		}
 	}
 	b.Run("0b-d-∞", func(b *testing.B) { formatSize(0, 'd', -1, b) })
+	b.Run("1bit-d-∞", func(b *testing.B) { formatSize(1, 'i', -1, b) })
+	b.Run("10b-d-∞", func(b *testing.B) { formatSize(10, 'd', -1, b) })
 	b.Run("1mb-d-∞", func(b *testing.B) { formatSize(MB, 'd', -1, b) })
+	b.Run("-1mb-d-∞", func(b *testing.B) { formatSize(MB, 'd', -1, b) })
 	b.Run("1mb-b-∞", func(b *testing.B) { formatSize(MB, 'b', -1, b) })
 	b.Run("1mb-i-∞", func(b *testing.B) { formatSize(MB, 'i', -1, b) })
 	b.Run("1mb-b-4", func(b *testing.B) { formatSize(MB, 'd', 4, b) })

--- a/examples_test.go
+++ b/examples_test.go
@@ -26,15 +26,15 @@ func ExampleParseSize() {
 }
 
 func ExampleFormatSize() {
-	fmt.Println(mem.FormatSize(1*mem.MB, 'd', -1))
+	fmt.Println(mem.FormatSize(1*mem.MB, 'D', -1))
 	fmt.Println(mem.FormatSize(1*mem.MB+111*mem.KB, 'd', 2))
-	fmt.Println(mem.FormatSize(2*mem.TiB+512*mem.MiB, 'b', 4))
+	fmt.Println(mem.FormatSize(2*mem.TiB+512*mem.MiB, 'B', 4))
 
-	fmt.Println(mem.FormatSize(5*mem.MBit, 'i', -1))
-	fmt.Println(mem.FormatSize(200*mem.MBit, 'd', -1))
+	fmt.Println(mem.FormatSize(5*mem.MBit, 'I', -1))
+	fmt.Println(mem.FormatSize(200*mem.MBit, 'D', -1))
 	// Output:
 	// 1MB
-	// 1.11MB
+	// 1.11mb
 	// 2.0005TiB
 	// 5Mbit
 	// 25MB

--- a/format.go
+++ b/format.go
@@ -97,64 +97,97 @@ func ParseSize(s string) (Size, error) {
 //
 // The format fmt specifies how to format the size s. Valid values
 // are:
-//   - 'd' formats s as "-ddd.dddddMB" using the decimal byte units.
-//   - 'b' formats s as "-ddd.dddddMiB" using the binary byte units.
-//   - 'i' formats s as "-ddd.dddddMbit" using the decimal bit units.
+//   - 'd' formats s as "-ddd.dddddmb" using the decimal byte units.
+//   - 'b' formats s as "-ddd.dddddmib" using the binary byte units.
+//   - 'i' formats s as "-ddd.dddddmbit" using the decimal bit units.
+//
+// In addition, 'D', 'B', 'I' format s similar to 'd', 'b' and 'i'
+// but with partially uppercase unit strings. In particular:
+//   - 'D' formats s as "-ddd.dddddMB" using the decimal byte units.
+//   - 'B' formats s as "-ddd.dddddMiB" using the binary byte units.
+//   - 'I' formats s as "-ddd.dddddMbit" using the decimal bit units.
 //
 // The precision prec controls the number of digits after the decimal
 // point printed by the 'd', 'b' and 'i' formats. The special precision
 // -1 uses the smallest number of digits necessary such that ParseSize
 // will return s exactly.
 func FormatSize(s Size, fmt byte, prec int) string {
+	if s == 0 { // Optimized path for the zero value
+		switch fmt {
+		case 'd', 'b':
+			return "0b"
+		case 'D', 'B':
+			return "0B"
+		case 'i':
+			return "0bit"
+		case 'I':
+			return "0Bit"
+		default:
+			return string([]byte{'%', fmt})
+		}
+	}
+
 	switch fmt {
-	case 'd':
+	case 'd', 'D':
+		var p, t, g, m, k, b string
+		if fmt == 'D' {
+			p, t, g, m, k, b = "PB", "TB", "GB", "MB", "KB", "B"
+		} else {
+			p, t, g, m, k, b = "pb", "tb", "gb", "mb", "kb", "b"
+		}
 		switch {
 		case s >= PB || s <= -PB:
-			return string(fmtSize(s, PB, prec, "PB"))
+			return string(fmtSize(s, PB, prec, p))
 		case s >= TB || s <= -TB:
-			return string(fmtSize(s, TB, prec, "TB"))
+			return string(fmtSize(s, TB, prec, t))
 		case s >= GB || s <= -GB:
-			return string(fmtSize(s, GB, prec, "GB"))
+			return string(fmtSize(s, GB, prec, g))
 		case s >= MB || s <= -MB:
-			return string(fmtSize(s, MB, prec, "MB"))
+			return string(fmtSize(s, MB, prec, m))
 		case s >= KB || s <= -KB:
-			return string(fmtSize(s, KB, prec, "KB"))
-		case s == 0:
-			return "0B"
+			return string(fmtSize(s, KB, prec, k))
 		default:
-			return strconv.FormatFloat(s.Bytes(), 'f', prec, 64) + "B"
+			return string(fmtSize(s, Byte, prec, b))
 		}
-	case 'b':
+	case 'b', 'B':
+		var p, t, g, m, k, b string
+		if fmt == 'B' {
+			p, t, g, m, k, b = "PiB", "TiB", "GiB", "MiB", "KiB", "B"
+		} else {
+			p, t, g, m, k, b = "pib", "tib", "gib", "mib", "kib", "b"
+		}
 		switch {
 		case s >= PiB || s <= -PiB:
-			return string(fmtSize(s, PiB, prec, "PiB"))
+			return string(fmtSize(s, PiB, prec, p))
 		case s >= TiB || s <= -TiB:
-			return string(fmtSize(s, TiB, prec, "TiB"))
+			return string(fmtSize(s, TiB, prec, t))
 		case s >= GiB || s <= -GiB:
-			return string(fmtSize(s, GiB, prec, "GiB"))
+			return string(fmtSize(s, GiB, prec, g))
 		case s >= MiB || s <= -MiB:
-			return string(fmtSize(s, MiB, prec, "MiB"))
+			return string(fmtSize(s, MiB, prec, m))
 		case s >= KiB || s <= -KiB:
-			return string(fmtSize(s, KiB, prec, "KiB"))
-		case s == 0:
-			return "0B"
+			return string(fmtSize(s, KiB, prec, k))
 		default:
-			return strconv.FormatFloat(s.Bytes(), 'f', prec, 64) + "B"
+			return string(fmtSize(s, Byte, prec, b))
 		}
-	case 'i':
+	case 'i', 'I':
+		var t, g, m, k, b string
+		if fmt == 'I' {
+			t, g, m, k, b = "Tbit", "Gbit", "Mbit", "Kbit", "Bit"
+		} else {
+			t, g, m, k, b = "tbit", "gbit", "mbit", "kbit", "bit"
+		}
 		switch {
 		case s >= TBit || s <= -TBit:
-			return string(fmtSize(s, TBit, prec, "Tbit"))
+			return string(fmtSize(s, TBit, prec, t))
 		case s >= GBit || s <= -GBit:
-			return string(fmtSize(s, GBit, prec, "Gbit"))
+			return string(fmtSize(s, GBit, prec, g))
 		case s >= MBit || s <= -MBit:
-			return string(fmtSize(s, MBit, prec, "Mbit"))
+			return string(fmtSize(s, MBit, prec, m))
 		case s >= KBit || s <= -KBit:
-			return string(fmtSize(s, KBit, prec, "Kbit"))
-		case s == 0:
-			return "0bit"
+			return string(fmtSize(s, KBit, prec, k))
 		default:
-			return strconv.FormatInt(int64(s), 10) + "bit"
+			return strconv.FormatInt(int64(s), 10) + b
 		}
 	default:
 		return string([]byte{'%', fmt})
@@ -201,6 +234,14 @@ func fmtSize(v, base Size, prec int, unit string) []byte {
 		}
 		rbuf := strconv.AppendFloat(nil, float64(r)/float64(base), 'f', prec, 64)
 		buf = make([]byte, 0, 4+prec+len(rbuf)+len(unit)) // The '.' is already included in rbuf
+		if v < 0 && m == 0 {
+			// When formatting a negative size like -4bit as -0.5b
+			// where the abs. value is small than the base,
+			// m = v / base will be zero.
+			// In this case, we have to add the minus sign manually
+			// since strconv.AppendInt(buf, 0, 10) will not add it.
+			buf = append(buf, '-')
+		}
 		buf = strconv.AppendInt(buf, int64(m), 10)
 		buf = append(buf, rbuf[1:]...)
 	}
@@ -218,7 +259,7 @@ func parseUnit(s string) (Size, bool) {
 		switch s {
 		case "b", "B":
 			return Byte, true
-		case "bit":
+		case "bit", "Bit":
 			return Bit, true
 		}
 	case 'k', 'K':

--- a/format_test.go
+++ b/format_test.go
@@ -4,24 +4,27 @@
 
 package mem
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 var formatSizeTests = []struct {
 	Size    Size
 	Prec    int
 	D, B, I string
 }{
-	{Size: 0, Prec: -1, D: "0B", B: "0B", I: "0bit"},                                                                      // 0
-	{Size: Bit, Prec: -1, D: "0.125B", B: "0.125B", I: "1bit"},                                                            // 1
-	{Size: Byte, Prec: -1, D: "1B", B: "1B", I: "8bit"},                                                                   // 2
-	{Size: -1 * Byte, Prec: -1, D: "-1B", B: "-1B", I: "-8bit"},                                                           // 3
-	{Size: 1*MB + 111*KB, Prec: -1, D: "1.111MB", B: "1.05953216552734375MiB", I: "8.888Mbit"},                            // 4
-	{Size: 1*MB + 111*KB, Prec: 2, D: "1.11MB", B: "1.06MiB", I: "8.89Mbit"},                                              // 5
-	{Size: -1*MB - 111*KB, Prec: -1, D: "-1.111MB", B: "-1.05953216552734375MiB", I: "-8.888Mbit"},                        // 6
-	{Size: 1*GiB + 512*MiB, Prec: -1, D: "1.610612736GB", B: "1.5GiB", I: "12.884901888Gbit"},                             // 7
-	{Size: 5 * TBit, Prec: -1, D: "625GB", B: "582.07660913467407227GiB", I: "5Tbit"},                                     // 8
-	{Size: MaxSize, Prec: -1, D: "1152.9215046068469759PB", B: "1023.9999999999999999PiB", I: "9223372.036854775807Tbit"}, // 9
-	{Size: minSize, Prec: -1, D: "-1152.921504606846976PB", B: "-1024PiB", I: "-9223372.036854775808Tbit"},                // 10
+	{Size: 0, Prec: -1, D: "0b", B: "0b", I: "0bit"},                                                                      // 0
+	{Size: Bit, Prec: -1, D: "0.125b", B: "0.125b", I: "1bit"},                                                            // 1
+	{Size: Byte, Prec: -1, D: "1b", B: "1b", I: "8bit"},                                                                   // 2
+	{Size: -1 * Byte, Prec: -1, D: "-1b", B: "-1b", I: "-8bit"},                                                           // 3
+	{Size: 1*MB + 111*KB, Prec: -1, D: "1.111mb", B: "1.05953216552734375mib", I: "8.888mbit"},                            // 4
+	{Size: 1*MB + 111*KB, Prec: 2, D: "1.11mb", B: "1.06mib", I: "8.89mbit"},                                              // 5
+	{Size: -1*MB - 111*KB, Prec: -1, D: "-1.111mb", B: "-1.05953216552734375mib", I: "-8.888mbit"},                        // 6
+	{Size: 1*GiB + 512*MiB, Prec: -1, D: "1.610612736gb", B: "1.5gib", I: "12.884901888gbit"},                             // 7
+	{Size: 5 * TBit, Prec: -1, D: "625gb", B: "582.07660913467407227gib", I: "5tbit"},                                     // 8
+	{Size: MaxSize, Prec: -1, D: "1152.9215046068469759pb", B: "1023.9999999999999999pib", I: "9223372.036854775807tbit"}, // 9
+	{Size: minSize, Prec: -1, D: "-1152.921504606846976pb", B: "-1024pib", I: "-9223372.036854775808tbit"},                // 10
 }
 
 func TestFormatSize(t *testing.T) {
@@ -38,6 +41,36 @@ func TestFormatSize(t *testing.T) {
 	}
 }
 
+var formatParseSizeTests = []Size{
+	0, Bit, Byte, 512 * Byte, -Bit, -Byte, -512 * Byte,
+	KBit, KB, KiB, 384 * KB, 384 * KiB, -KBit, -KB, -KiB, -732 * KB, -732 * KiB,
+	MBit, MB, MiB, 18 * MB, 81 * MiB, -MBit, -MB, -MiB, -963 * MB, -963 * KiB,
+	GBit, GB, GiB, 740 * GB, 59 * GiB, -GBit, -GB, -GiB, -64*GB - 837*MB - 848*Byte,
+	TBit, TB, TiB, 182 * TB, 485 * TiB, -TBit, -TB, -TiB, 301*TB + 643*MB - 553*Byte,
+	PB, PiB, 871 * PB, 131 * PiB, -PB, -PiB, MaxSize, minSize,
+}
+
+func TestFormatParseSize(t *testing.T) {
+	fmts := []byte{'d', 'b', 'i', 'D', 'B', 'I'}
+	precs := []int{-1, 16}
+	for _, f := range fmts {
+		for _, prec := range precs {
+			for _, s := range formatParseSizeTests {
+				v := FormatSize(s, f, prec)
+				w, err := ParseSize(v)
+				if err != nil {
+					details := fmt.Sprintf("formatted '%d' with fmt='%c' and prec='%d'", s, f, prec)
+					t.Fatalf("Failed to parse size string '%s' - %s", v, details)
+				}
+				if w != s {
+					details := fmt.Sprintf("formatted '%d' with fmt='%c' and prec='%d'", s, f, prec)
+					t.Fatalf("Parsed size does not match original size: got '%v' ('%d') - want '%v' ('%d') - %s", w, w, s, s, details)
+				}
+			}
+		}
+	}
+}
+
 var parseSizeTests = []struct {
 	String     string
 	Size       Size
@@ -45,7 +78,7 @@ var parseSizeTests = []struct {
 }{
 	{String: "0B", Size: 0},                                 // 0
 	{String: "0bit", Size: 0},                               // 1
-	{String: "+0bit", Size: 0},                              // 2
+	{String: "+0Bit", Size: 0},                              // 2
 	{String: "-0bit", Size: 0},                              // 3
 	{String: "1bit", Size: Bit},                             // 4
 	{String: "+1bit", Size: Bit},                            // 5
@@ -69,7 +102,6 @@ var parseSizeTests = []struct {
 	{String: "-1152.921504606846976PB", Size: minSize},      // 23
 
 	{String: "0", ShouldFail: true},
-	{String: "0Bit", ShouldFail: true},
 	{String: "--0bit", ShouldFail: true},
 	{String: "+-0bit", ShouldFail: true},
 	{String: " 0B", ShouldFail: true},

--- a/size.go
+++ b/size.go
@@ -226,7 +226,7 @@ func (s Size) Round(m Size) Size {
 
 // String returns a string representing the size in the form "1.25MB".
 // The zero size formats as 0B.
-func (s Size) String() string { return FormatSize(s, 'd', -1) }
+func (s Size) String() string { return FormatSize(s, 'D', -1) }
 
 func lessThanHalf(x, y Size) bool {
 	return uint64(x)+uint64(x) < uint64(y)


### PR DESCRIPTION
This commit changes the `FormatSize` formatting.

The previous `'d', 'b' and 'i'` formats now
return lowercase units - e.g. `mb`, `mib` and `mbit`.

The new `'D', 'B', and 'I'` formats return
partial uppercase units - e.g. `MB`, `MiB` and `Mbit`.

As part of this change this commit fixes one bug that caused `FormatSize`
to convert `-1 * Bit` incorrectly to the string `"1bit"`.