### PR TITLE
add Bandwidth type

### DIFF
--- a/bandwidth.go
+++ b/bandwidth.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2022 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package mem
+
+// Common bandwidths for measuring internet / network speed.
+const (
+	BitPerSecond  Bandwidth = 1
+	KBitPerSecond           = 1000 * BitPerSecond
+	MBitPerSecond           = 1000 * KBitPerSecond
+	GBitPerSecond           = 1000 * MBitPerSecond
+	TBitPerSecond           = 1000 * GBitPerSecond
+)
+
+// Common bandwidths for drive and memory throughput.
+//
+// To count the number of units in a Bandwidth, divide:
+//
+//	mbps := mem.MBytePerSecond
+//	fmt.Print(int64(mbps / mem.KBytePerSecond)) // prints 1000
+//
+// To convert an integer of units to a Bandwidth, multiply:
+//
+//	mbps := 10
+//	fmt.Print(mem.Bandwidth(mbps)*mem.MBytePerSecond) // prints 10MB
+const (
+	BytePerSecond Bandwidth = 8 * BitPerSecond
+
+	KBytePerSecond Bandwidth = 1000 * BytePerSecond
+	MBytePerSecond           = 1000 * KBytePerSecond
+	GBytePerSecond           = 1000 * MBytePerSecond
+	TBytePerSecond           = 1000 * GBytePerSecond
+
+	KiBytePerSecond Bandwidth = 1024 * BytePerSecond
+	MiBytePerSecond           = 1024 * KiBytePerSecond
+	GiBytePerSecond           = 1024 * MiBytePerSecond
+	TiBytePerSecond           = 1024 * GiBytePerSecond
+)
+
+// Bandwidth represents an amount of data per second as
+// int64 number of bits/s.
+type Bandwidth int64
+
+// Kilobits returns the bandwidth as floating point number
+// of kilobits per second (Kbit/s).
+func (b Bandwidth) Kilobits() float64 {
+	return Size(b).Kilobits()
+}
+
+// Megabits returns the bandwidth as floating point number
+// of megabits per second (Mbit/s).
+func (b Bandwidth) Megabits() float64 {
+	return Size(b).Megabits()
+}
+
+// Gigabits returns the bandwidth as floating point number
+// of gigabits per second (Gbit/s).
+func (b Bandwidth) Gigabits() float64 {
+	return Size(b).Gigabits()
+}
+
+// Terabits returns the bandwidth as floating point number
+// of terabits per second (Tbit/s).
+func (b Bandwidth) Terabits() float64 {
+	return Size(b).Terabits()
+}
+
+// Bytes returns the bandwidth as floating point number
+// of bytes per second (B/s).
+func (b Bandwidth) Bytes() float64 {
+	return Size(b).Bytes()
+}
+
+// Kilobytes returns the bandwidth as floating point number
+// of kilobytes per second (KB/s).
+func (b Bandwidth) Kilobytes() float64 {
+	return Size(b).Kilobytes()
+}
+
+// Megabytes returns the bandwidth as floating point number
+// of megabytes per second (MB/s).
+func (b Bandwidth) Megabytes() float64 {
+	return Size(b).Megabytes()
+}
+
+// Gigabytes returns the bandwidth as floating point number
+// of gigabytes per second (GB/s).
+func (b Bandwidth) Gigabytes() float64 {
+	return Size(b).Abs().Gigabytes()
+}
+
+// Terabytes returns the bandwidth as floating point number
+// of megabytes per second (TB/s).
+func (b Bandwidth) Terabytes() float64 {
+	return Size(b).Terabytes()
+}
+
+// Kibibytes returns the bandwidth as floating point number
+// of kibibytes per second (KiB/s).
+func (b Bandwidth) Kibibytes() float64 {
+	return Size(b).Kibibytes()
+}
+
+// Mebibytes returns the bandwidth as floating point number
+// of mebibytes per second (MiB/s).
+func (b Bandwidth) Mebibytes() float64 {
+	return Size(b).Mebibytes()
+}
+
+// Gibibytes returns the bandwidth as floating point number
+// of Gibibytes per second (GiB/s).
+func (b Bandwidth) Gibibytes() float64 {
+	return Size(b).Gibibytes()
+}
+
+// Tebibytes returns the bandwidth as floating point number
+// of Tebibytes per second (TiB/s).
+func (b Bandwidth) Tebibytes() float64 {
+	return Size(b).Tebibytes()
+}
+
+// Truncate returns the result of rounding b towards zero to a
+// multiple of m. If m <= 0, Truncate returns b unchanged.
+func (b Bandwidth) Truncate(m Bandwidth) Bandwidth {
+	return Bandwidth(Size(b).Truncate(Size(m)))
+}
+
+// Round returns the result of rounding b to the nearest multiple of m.
+// The rounding behavior for halfway values is to round away from zero.
+// If the result exceeds the maximum (or minimum) value that can be
+// stored in a Bandwidth, Round returns the maximum (or minimum) bandwidth.
+// If m <= 0, Round returns b unchanged.
+func (b Bandwidth) Round(m Bandwidth) Bandwidth {
+	return Bandwidth(Size(b).Round(Size(m)))
+}
+
+// Abs returns the absolute value of b. As a special case,
+// math.MinInt64 is converted to math.MaxInt64.
+func (b Bandwidth) Abs() Bandwidth {
+	return Bandwidth(Size(b).Abs())
+}
+
+// String returns a string representing the bandwidth in the form "1.25MB/s".
+// The zero bandwidth formats as 0B/s.
+func (b Bandwidth) String() string { return FormatBandwidth(b, 'D', -1) }

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+// Package mem provides functionality for measuring and displaying
+// memory throughput and capacity.
+//
+// # Units
+//
+// The fundamental unit of data is the bit. For example, networking
+// speed is usually measured in bits per second. Large quantities of
+// bits are commonly displayed using the SI / decimal prefixes for
+// powers of 10:
+//
+//	Unit |    Amount
+//	----------------
+//	 Bit |    1
+//	Kbit | 1000 Bit
+//	Mbit | 1000 Kbit
+//	Gbit | 1000 Mbit
+//	Tbit | 1000 Gbit
+//
+// In contrast, storage capacity is usually measured in bytes.
+// For large quantities of bytes there are two commonly used
+// prefix scales - the SI / decimal prefixes for powers of 10
+// and the binary prefixes for powers of 2:
+//
+//	Unit (decimal) |    Amount      Unit (binary) |    Amount
+//	--------------------------      -------------------------
+//	          Byte |    8 Bit                Byte |    8 Bit
+//	            KB | 1000 Byte                KiB | 1024 Byte
+//	            MB | 1000 KB                  MiB | 1024 KiB
+//	            GB | 1000 MB                  GiB | 1024 MiB
+//	            TB | 1000 GB                  TiB | 1024 GiB
+//	            PB | 1000 TB                  PiB | 1024 TiB
+//
+// Most software and operating systems, like macOS or linux report
+// file sizes in decimal units. This is consistent with other units
+// for computers, like CPU clock or networking speeds.
+// One prominent example that uses the binary instead of decimal
+// units is MS Windows.
+//
+// # Formatting
+//
+// Sizes and bandwidths can be formatted and displayed in various
+// units and with various precisions. The formats 'd/D', 'b/B' and
+// 'i/I' are used for lower and uppercase decimal, binary and deciaml
+// bit prefixes. For example:
+//
+//	d := mem.FormatSize(1*mem.MB, 'd', -1) // "1mb"
+//	D := mem.FormatSize(1*mem.MB, 'D', -1) // "1MB"
+//	b := mem.FormatSize(1*mem.MB, 'b', -1) // "976.5625kib"
+//	B := mem.FormatSize(1*mem.MB, 'B', -1) // "976.5625KiB"
+//	i := mem.FormatSize(1*mem.MB, 'i', -1) // "1mbit"
+//	I := mem.FormatSize(1*mem.MB, 'I', -1) // "1Mbit"
+package mem

--- a/examples_test.go
+++ b/examples_test.go
@@ -11,6 +11,20 @@ import (
 	"aead.dev/mem"
 )
 
+func ExampleParseBandwidth() {
+	a, err := mem.ParseBandwidth("1.123MB/s")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	b, err := mem.ParseBandwidth("3.877MB/s")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	fmt.Println(a + b)
+	// Output:
+	// 5MB/s
+}
+
 func ExampleParseSize() {
 	a, err := mem.ParseSize("1.123MB")
 	if err != nil {
@@ -23,6 +37,21 @@ func ExampleParseSize() {
 	fmt.Println(a + b)
 	// Output:
 	// 5MB
+}
+
+func ExampleFormatBandwidth() {
+	fmt.Println(mem.FormatBandwidth(1*mem.MBytePerSecond, 'D', -1))
+	fmt.Println(mem.FormatBandwidth(1*mem.MBytePerSecond+111*mem.KBytePerSecond, 'd', 2))
+	fmt.Println(mem.FormatBandwidth(2*mem.TiBytePerSecond+512*mem.MiBytePerSecond, 'B', 4))
+
+	fmt.Println(mem.FormatBandwidth(5*mem.MBitPerSecond, 'I', -1))
+	fmt.Println(mem.FormatBandwidth(200*mem.MBitPerSecond, 'D', -1))
+	// Output:
+	// 1MB/s
+	// 1.11mb/s
+	// 2.0005TiB/s
+	// 5Mbit/s
+	// 25MB/s
 }
 
 func ExampleFormatSize() {
@@ -40,6 +69,13 @@ func ExampleFormatSize() {
 	// 25MB
 }
 
+func ExampleSize_PerSecond() {
+	size := 1 * mem.MB
+	fmt.Println(size.PerSecond())
+	// Output:
+	// 1MB/s
+}
+
 func ExampleSize_String() {
 	fmt.Println(1 * mem.MB)
 	fmt.Println(1*mem.GB + 500*mem.MB)
@@ -50,4 +86,16 @@ func ExampleSize_String() {
 	// 1.5GB
 	// 6KB
 	// 5GB
+}
+
+func ExampleBandwidth_String() {
+	fmt.Println(1 * mem.MBytePerSecond)
+	fmt.Println(1*mem.GBytePerSecond + 500*mem.MBytePerSecond)
+	fmt.Println(5*mem.KiBytePerSecond + 880*mem.BytePerSecond)
+	fmt.Println(40 * mem.GBitPerSecond)
+	// Output:
+	// 1MB/s
+	// 1.5GB/s
+	// 6KB/s
+	// 5GB/s
 }

--- a/size.go
+++ b/size.go
@@ -2,58 +2,9 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file.
 
-// Package mem provides functionality for measuring and displaying
-// memory throughput and capacity.
-//
-// # Units
-//
-// The fundamental unit of data is the bit. For example, networking
-// speed is usually measured in bits per second. Large quantities of
-// bits are commonly displayed using the SI / decimal prefixes for
-// powers of 10:
-//
-//	Unit |    Amount
-//	----------------
-//	 Bit |    1
-//	Kbit | 1000 Bit
-//	Mbit | 1000 Kbit
-//	Gbit | 1000 Mbit
-//	Tbit | 1000 Gbit
-//
-// In contrast, storage capacity is usually measured in bytes.
-// For large quantities of bytes there are two commonly used
-// prefix scales - the SI / decimal prefixes for powers of 10
-// and the binary prefixes for powers of 2:
-//
-//	Unit (decimal) |    Amount      Unit (binary) |    Amount
-//	--------------------------      -------------------------
-//	          Byte |    8 Bit                Byte |    8 Bit
-//	            KB | 1000 Byte                KiB | 1024 Byte
-//	            MB | 1000 KB                  MiB | 1024 KiB
-//	            GB | 1000 MB                  GiB | 1024 MiB
-//	            TB | 1000 GB                  TiB | 1024 GiB
-//	            PB | 1000 TB                  PiB | 1024 TiB
-//
-// Most software and operating systems, like macOS or linux report
-// file sizes in decimal units. One prominent example that uses the
-// binary units is windows.
-//
-// # Formatting
-//
-// Sizes can be formatted and displayed in various units and with
-// various precisions. The formats 'd/D', 'b/B' and 'i/I' are used
-// for lower and uppercase decimal, binary and deciaml bit prefixes.
-// For example:
-//
-//	d := mem.FormatSize(1*mem.MB, 'd', -1) // "1mb"
-//	D := mem.FormatSize(1*mem.MB, 'D', -1) // "1MB"
-//	b := mem.FormatSize(1*mem.MB, 'b', -1) // "976.5625kib"
-//	B := mem.FormatSize(1*mem.MB, 'B', -1) // "976.5625KiB"
-//	i := mem.FormatSize(1*mem.MB, 'i', -1) // "1mbit"
-//	I := mem.FormatSize(1*mem.MB, 'I', -1) // "1Mbit"
 package mem
 
-// Common sizes for measuring internet / network speed.
+// Common sizes when measuring amounts of data in bits.
 const (
 	Bit  Size = 1
 	KBit      = 1000 * Bit
@@ -63,23 +14,6 @@ const (
 )
 
 // Common sizes for measuring memory and disk capacity.
-//
-// There are two commonly used unit systems for measuring capacities.
-// The decimal unit of data uses the kilo, mega giga prefixes as
-// multipliers of 1000. For example, 1000 byte = 1 kilobyte (KB) and
-// 1000 KB = 1 megabyte (MB). This definition has been incorporated
-// into the International System of Quantities. It is consistent
-// with other unit systems for computers, like CPU clock or networking
-// speeds.
-//
-// In contrast, the binary unit of data uses the kibi, mebi, gibi
-// prefixes as multipliers of 1024 or 2^10. For example,
-// 1024 byte = 1 kibibyte (KiB) and 1024 kibibyte = 1 mebibyte (MiB).
-// The binary unit of data is used by e.g. MS Windows for computer
-// memory like RAM or caches.
-//
-// Both, the binary and decimal unit of data, use the one byte (8 bit)
-// as base unit.
 //
 // To count the number of units in a Size, divide:
 //
@@ -113,32 +47,32 @@ const (
 	minSize Size = -1 << 63
 )
 
-// Size represents an amount of memory as int64 number of bits.
+// Size represents an amount of data as int64 number of bits.
 // The largest representable size is approximately one exabyte.
 type Size int64
 
-// Kilobits returns the size as floating point number of kilobits (KBit).
+// Kilobits returns the size as floating point number of kilobits (Kbit).
 func (s Size) Kilobits() float64 {
 	k := s / KBit
 	r := s % KBit
 	return float64(k) + float64(r)/1e3
 }
 
-// Megabits returns the size as floating point number of megabits (MBit).
+// Megabits returns the size as floating point number of megabits (Mbit).
 func (s Size) Megabits() float64 {
 	m := s / MBit
 	r := s % MBit
 	return float64(m) + float64(r)/1e6
 }
 
-// Gigabits returns the size as floating point number of gigabits (GBit).
+// Gigabits returns the size as floating point number of gigabits (Gbit).
 func (s Size) Gigabits() float64 {
 	g := s / GBit
 	r := s % GBit
 	return float64(g) + float64(r)/1e9
 }
 
-// Terabits returns the size as floating point number of terabits (TBit).
+// Terabits returns the size as floating point number of terabits (Tbit).
 func (s Size) Terabits() float64 {
 	t := s / TBit
 	r := s % TBit
@@ -272,6 +206,9 @@ func (s Size) Round(m Size) Size {
 	}
 	return MaxSize // overflow
 }
+
+// PerSecond converts the size to a bandwidth as size per second.
+func (s Size) PerSecond() Bandwidth { return Bandwidth(s) }
 
 // String returns a string representing the size in the form "1.25MB".
 // The zero size formats as 0B.


### PR DESCRIPTION
This commit adds the `Bandwidth` type
that represents a Size per second.

We consider `Bandwidth` to be always normalized
to 1s. Most users will probably care only ever
about sizes per second, e.g. MB/s and not about
e.g. MB/ms.

Further, it is easy to add or subtract bandwidths. For example:
```
1.5MB/s = 1MB/s + 500KB/s
```

When dealing with arbitrary durations like 1MB/1.7ms a different type may be better suited:
```
type Rate struct {
  N Size
  T time.Duration
}
```