### PR TITLE
refactor size representation

### DIFF
--- a/bandwidth.go
+++ b/bandwidth.go
@@ -4,15 +4,6 @@
 
 package mem
 
-// Common bandwidths for measuring internet / network speed.
-const (
-	BitPerSecond  Bandwidth = 1
-	KBitPerSecond           = 1000 * BitPerSecond
-	MBitPerSecond           = 1000 * KBitPerSecond
-	GBitPerSecond           = 1000 * MBitPerSecond
-	TBitPerSecond           = 1000 * GBitPerSecond
-)
-
 // Common bandwidths for drive and memory throughput.
 //
 // To count the number of units in a Bandwidth, divide:
@@ -25,7 +16,7 @@ const (
 //	mbps := 10
 //	fmt.Print(mem.Bandwidth(mbps)*mem.MBytePerSecond) // prints 10MB
 const (
-	BytePerSecond Bandwidth = 8 * BitPerSecond
+	BytePerSecond Bandwidth = 1
 
 	KBytePerSecond Bandwidth = 1000 * BytePerSecond
 	MBytePerSecond           = 1000 * KBytePerSecond
@@ -36,6 +27,14 @@ const (
 	MiBytePerSecond           = 1024 * KiBytePerSecond
 	GiBytePerSecond           = 1024 * MiBytePerSecond
 	TiBytePerSecond           = 1024 * GiBytePerSecond
+)
+
+// Common bandwidths for measuring internet / network speed.
+const (
+	KBitPerSecond = 125 * BytePerSecond
+	MBitPerSecond = 1000 * KBitPerSecond
+	GBitPerSecond = 1000 * MBitPerSecond
+	TBitPerSecond = 1000 * GBitPerSecond
 )
 
 // Bandwidth represents an amount of data per second as

--- a/doc.go
+++ b/doc.go
@@ -43,14 +43,12 @@
 // # Formatting
 //
 // Sizes and bandwidths can be formatted and displayed in various
-// units and with various precisions. The formats 'd/D', 'b/B' and
-// 'i/I' are used for lower and uppercase decimal, binary and deciaml
-// bit prefixes. For example:
+// units and with various precisions. The formats 'd/D' and 'b/B'
+// are used for lower and uppercase decimal and binary prefixes.
+// For example:
 //
 //	d := mem.FormatSize(1*mem.MB, 'd', -1) // "1mb"
 //	D := mem.FormatSize(1*mem.MB, 'D', -1) // "1MB"
 //	b := mem.FormatSize(1*mem.MB, 'b', -1) // "976.5625kib"
 //	B := mem.FormatSize(1*mem.MB, 'B', -1) // "976.5625KiB"
-//	i := mem.FormatSize(1*mem.MB, 'i', -1) // "1mbit"
-//	I := mem.FormatSize(1*mem.MB, 'I', -1) // "1Mbit"
 package mem

--- a/examples_test.go
+++ b/examples_test.go
@@ -43,14 +43,11 @@ func ExampleFormatBandwidth() {
 	fmt.Println(mem.FormatBandwidth(1*mem.MBytePerSecond, 'D', -1))
 	fmt.Println(mem.FormatBandwidth(1*mem.MBytePerSecond+111*mem.KBytePerSecond, 'd', 2))
 	fmt.Println(mem.FormatBandwidth(2*mem.TiBytePerSecond+512*mem.MiBytePerSecond, 'B', 4))
-
-	fmt.Println(mem.FormatBandwidth(5*mem.MBitPerSecond, 'I', -1))
 	fmt.Println(mem.FormatBandwidth(200*mem.MBitPerSecond, 'D', -1))
 	// Output:
 	// 1MB/s
 	// 1.11mb/s
 	// 2.0005TiB/s
-	// 5Mbit/s
 	// 25MB/s
 }
 
@@ -59,13 +56,11 @@ func ExampleFormatSize() {
 	fmt.Println(mem.FormatSize(1*mem.MB+111*mem.KB, 'd', 2))
 	fmt.Println(mem.FormatSize(2*mem.TiB+512*mem.MiB, 'B', 4))
 
-	fmt.Println(mem.FormatSize(5*mem.MBit, 'I', -1))
 	fmt.Println(mem.FormatSize(200*mem.MBit, 'D', -1))
 	// Output:
 	// 1MB
 	// 1.11mb
 	// 2.0005TiB
-	// 5Mbit
 	// 25MB
 }
 

--- a/format_test.go
+++ b/format_test.go
@@ -10,21 +10,19 @@ import (
 )
 
 var formatSizeTests = []struct {
-	Size    Size
-	Prec    int
-	D, B, I string
+	Size Size
+	Prec int
+	D, B string
 }{
-	{Size: 0, Prec: -1, D: "0b", B: "0b", I: "0bit"},                                                                      // 0
-	{Size: Bit, Prec: -1, D: "0.125b", B: "0.125b", I: "1bit"},                                                            // 1
-	{Size: Byte, Prec: -1, D: "1b", B: "1b", I: "8bit"},                                                                   // 2
-	{Size: -1 * Byte, Prec: -1, D: "-1b", B: "-1b", I: "-8bit"},                                                           // 3
-	{Size: 1*MB + 111*KB, Prec: -1, D: "1.111mb", B: "1.05953216552734375mib", I: "8.888mbit"},                            // 4
-	{Size: 1*MB + 111*KB, Prec: 2, D: "1.11mb", B: "1.06mib", I: "8.89mbit"},                                              // 5
-	{Size: -1*MB - 111*KB, Prec: -1, D: "-1.111mb", B: "-1.05953216552734375mib", I: "-8.888mbit"},                        // 6
-	{Size: 1*GiB + 512*MiB, Prec: -1, D: "1.610612736gb", B: "1.5gib", I: "12.884901888gbit"},                             // 7
-	{Size: 5 * TBit, Prec: -1, D: "625gb", B: "582.07660913467407227gib", I: "5tbit"},                                     // 8
-	{Size: MaxSize, Prec: -1, D: "1152.9215046068469759pb", B: "1023.9999999999999999pib", I: "9223372.036854775807tbit"}, // 9
-	{Size: minSize, Prec: -1, D: "-1152.921504606846976pb", B: "-1024pib", I: "-9223372.036854775808tbit"},                // 10
+	{Size: 0, Prec: -1, D: "0b", B: "0b"},                                                 // 0
+	{Size: Byte, Prec: -1, D: "1b", B: "1b"},                                              // 2
+	{Size: -1 * Byte, Prec: -1, D: "-1b", B: "-1b"},                                       // 3
+	{Size: 1*MB + 111*KB, Prec: -1, D: "1.111mb", B: "1.05953216552734375mib"},            // 4
+	{Size: 1*MB + 111*KB, Prec: 2, D: "1.11mb", B: "1.06mib"},                             // 5
+	{Size: -1*MB - 111*KB, Prec: -1, D: "-1.111mb", B: "-1.05953216552734375mib"},         // 6
+	{Size: 1*GiB + 512*MiB, Prec: -1, D: "1.610612736gb", B: "1.5gib"},                    // 7
+	{Size: 5 * TBit, Prec: -1, D: "625gb", B: "582.07660913467407227gib"},                 // 8
+	{Size: MaxSize, Prec: -1, D: "9223.372036854775807pb", B: "8191.9999999999999991pib"}, // 8
 }
 
 func TestFormatSize(t *testing.T) {
@@ -35,14 +33,11 @@ func TestFormatSize(t *testing.T) {
 		if b := FormatSize(test.Size, 'b', test.Prec); b != test.B {
 			t.Fatalf("Test %d: format 'b': got %s - want %s", i, b, test.B)
 		}
-		if s := FormatSize(test.Size, 'i', test.Prec); s != test.I {
-			t.Fatalf("Test %d: format 'i': got %s - want %s", i, s, test.I)
-		}
 	}
 }
 
 var formatParseSizeTests = []Size{
-	0, Bit, Byte, 512 * Byte, -Bit, -Byte, -512 * Byte,
+	0, Byte, 512 * Byte, -Byte, -512 * Byte,
 	KBit, KB, KiB, 384 * KB, 384 * KiB, -KBit, -KB, -KiB, -732 * KB, -732 * KiB,
 	MBit, MB, MiB, 18 * MB, 81 * MiB, -MBit, -MB, -MiB, -963 * MB, -963 * KiB,
 	GBit, GB, GiB, 740 * GB, 59 * GiB, -GBit, -GB, -GiB, -64*GB - 837*MB - 848*Byte,
@@ -51,7 +46,7 @@ var formatParseSizeTests = []Size{
 }
 
 func TestFormatParseSize(t *testing.T) {
-	fmts := []byte{'d', 'b', 'i', 'D', 'B', 'I'}
+	fmts := []byte{'d', 'b', 'D', 'B'}
 	precs := []int{-1, 16}
 	for _, f := range fmts {
 		for _, prec := range precs {
@@ -77,37 +72,27 @@ var parseSizeTests = []struct {
 	ShouldFail bool
 }{
 	{String: "0B", Size: 0},                                 // 0
-	{String: "0bit", Size: 0},                               // 1
-	{String: "+0Bit", Size: 0},                              // 2
-	{String: "-0bit", Size: 0},                              // 3
-	{String: "1bit", Size: Bit},                             // 4
-	{String: "+1bit", Size: Bit},                            // 5
-	{String: "0.125B", Size: Bit},                           // 6
-	{String: "8bit", Size: Byte},                            // 7
-	{String: "1B", Size: Byte},                              // 8
-	{String: "-1B", Size: -Byte},                            // 9
-	{String: "1.5B", Size: Byte + 4*Bit},                    // 10
-	{String: "-1.75B", Size: -Byte - 6*Bit},                 // 11
-	{String: "1MB", Size: MB},                               // 12
-	{String: "1.111MB", Size: 1*MB + 111*KB},                // 13
-	{String: "1.05953216552734375MiB", Size: 1*MB + 111*KB}, // 14
-	{String: "8.888Mbit", Size: 1*MB + 111*KB},              // 15
-	{String: "1.610612736gb", Size: 1*GiB + 512*MiB},        // 16
-	{String: "1.5gib", Size: 1*GiB + 512*MiB},               // 17
-	{String: "12.884901888gbit", Size: 1*GiB + 512*MiB},     // 18
-	{String: "582.07660913467407227GiB", Size: 5 * TBit},    // 19
-	{String: "1023.9999999999999999PiB", Size: MaxSize},     // 20
-	{String: "9223372036854775807bit", Size: MaxSize},       // 21
-	{String: "-1024PiB", Size: minSize},                     // 22
-	{String: "-1152.921504606846976PB", Size: minSize},      // 23
+	{String: "+1b", Size: Byte},                             // 1
+	{String: "-1b", Size: -Byte},                            // 2
+	{String: "1B", Size: Byte},                              // 3
+	{String: "-8B", Size: -8 * Byte},                        // 4
+	{String: "1MB", Size: MB},                               // 5
+	{String: "1.111MB", Size: 1*MB + 111*KB},                // 6
+	{String: "1.05953216552734375MiB", Size: 1*MB + 111*KB}, // 7
+	{String: "1.610612736gb", Size: 1*GiB + 512*MiB},        // 8
+	{String: "1.5gib", Size: 1*GiB + 512*MiB},               // 9
+	{String: "582.07660913467407227GiB", Size: 5 * TBit},    // 10
+	{String: "8191.99999999999999991PiB", Size: MaxSize},    // 11
 
-	{String: "0", ShouldFail: true},
-	{String: "--0bit", ShouldFail: true},
-	{String: "+-0bit", ShouldFail: true},
-	{String: " 0B", ShouldFail: true},
-	{String: "0B ", ShouldFail: true},
-	{String: "0.125.0B ", ShouldFail: true},
-	{String: "1.25.0B ", ShouldFail: true},
+	{String: "0", ShouldFail: true},          // 12
+	{String: "--0b", ShouldFail: true},       // 13
+	{String: "+-0b", ShouldFail: true},       // 14
+	{String: " 0B", ShouldFail: true},        // 15
+	{String: "0B ", ShouldFail: true},        // 16
+	{String: "1.125.0KB ", ShouldFail: true}, // 17
+	{String: "1.25.0KB ", ShouldFail: true},  // 18
+	{String: "8bit ", ShouldFail: true},      // 19
+	{String: "8Kbit ", ShouldFail: true},     // 20
 }
 
 func TestParseSize(t *testing.T) {

--- a/size.go
+++ b/size.go
@@ -4,15 +4,6 @@
 
 package mem
 
-// Common sizes when measuring amounts of data in bits.
-const (
-	Bit  Size = 1
-	KBit      = 1000 * Bit
-	MBit      = 1000 * KBit
-	GBit      = 1000 * MBit
-	TBit      = 1000 * GBit
-)
-
 // Common sizes for measuring memory and disk capacity.
 //
 // To count the number of units in a Size, divide:
@@ -25,7 +16,7 @@ const (
 //	megabytes := 10
 //	fmt.Print(mem.Size(megabytes)*mem.MB) // prints 10MB
 const (
-	Byte = 8 * Bit
+	Byte Size = 1
 
 	KB Size = 1000 * Byte
 	MB      = 1000 * KB
@@ -40,43 +31,51 @@ const (
 	PiB      = 1024 * TiB
 )
 
+// Common sizes when measuring amounts of data in bits.
 const (
-	// MaxSize is the largest representable size: 1024PiB - 1bit.
+	KBit Size = 125 * Byte
+	MBit      = 1000 * KBit
+	GBit      = 1000 * MBit
+	TBit      = 1000 * GBit
+)
+
+const (
+	// MaxSize is the largest representable size: 8192PiB - 1bit.
 	MaxSize Size = 1<<63 - 1
 
 	minSize Size = -1 << 63
 )
 
-// Size represents an amount of data as int64 number of bits.
-// The largest representable size is approximately one exabyte.
+// Size represents an amount of data as int64 number of bytes.
+// The largest representable size is approximately 8192 PiB.
 type Size int64
 
 // Kilobits returns the size as floating point number of kilobits (Kbit).
 func (s Size) Kilobits() float64 {
 	k := s / KBit
 	r := s % KBit
-	return float64(k) + float64(r)/1e3
+	return float64(k) + float64(r)/(1e3/8)
 }
 
 // Megabits returns the size as floating point number of megabits (Mbit).
 func (s Size) Megabits() float64 {
 	m := s / MBit
 	r := s % MBit
-	return float64(m) + float64(r)/1e6
+	return float64(m) + float64(r)/(1e6/8)
 }
 
 // Gigabits returns the size as floating point number of gigabits (Gbit).
 func (s Size) Gigabits() float64 {
 	g := s / GBit
 	r := s % GBit
-	return float64(g) + float64(r)/1e9
+	return float64(g) + float64(r)/(1e9/8)
 }
 
 // Terabits returns the size as floating point number of terabits (Tbit).
 func (s Size) Terabits() float64 {
 	t := s / TBit
 	r := s % TBit
-	return float64(t) + float64(r)/1e12
+	return float64(t) + float64(r)/(1e12/8)
 }
 
 // Bytes returns the size as floating point number of bytes.
@@ -90,70 +89,70 @@ func (s Size) Bytes() float64 {
 func (s Size) Kilobytes() float64 {
 	k := s / KB
 	r := s % KB
-	return float64(k) + float64(r)/(8*1e3)
+	return float64(k) + float64(r)/1e3
 }
 
 // Megabytes returns the size as floating point number of megabytes (MB).
 func (s Size) Megabytes() float64 {
 	m := s / MB
 	r := s % MB
-	return float64(m) + float64(r)/(8*1e6)
+	return float64(m) + float64(r)/1e6
 }
 
 // Gigabytes returns the size as floating point number of gigabytes (GB).
 func (s Size) Gigabytes() float64 {
 	g := s / GB
 	r := s % GB
-	return float64(g) + float64(r)/(8*1e9)
+	return float64(g) + float64(r)/1e9
 }
 
 // Terabytes returns the size as floating point number of terabytes (TB).
 func (s Size) Terabytes() float64 {
 	t := s / TB
 	r := s % TB
-	return float64(t) + float64(r)/(8*1e12)
+	return float64(t) + float64(r)/1e12
 }
 
 // Petabytes returns the size as floating point number of petabytes (PB).
 func (s Size) Petabytes() float64 {
 	p := s / PB
 	r := s % PB
-	return float64(p) + float64(r)/(8*1e15)
+	return float64(p) + float64(r)/1e15
 }
 
 // Kibibytes returns the size as floating point number of kibibytes (KiB).
 func (s Size) Kibibytes() float64 {
 	k := s / KiB
 	r := s % KiB
-	return float64(k) + float64(r)/(8*(1<<10))
+	return float64(k) + float64(r)/(1<<10)
 }
 
 // Mebibytes returns the size as floating point number of mebibytes (MiB).
 func (s Size) Mebibytes() float64 {
 	m := s / MiB
 	r := s % MiB
-	return float64(m) + float64(r)/(8*(1<<20))
+	return float64(m) + float64(r)/(1<<20)
 }
 
 // Gibibytes returns the size as floating point number of gibibytes (GiB).
 func (s Size) Gibibytes() float64 {
 	g := s / GiB
 	r := s % GiB
-	return float64(g) + float64(r)/(8*(1<<30))
+	return float64(g) + float64(r)/(1<<30)
 }
 
 // Tebibytes returns the size as floating point number of tebibytes (TiB).
 func (s Size) Tebibytes() float64 {
 	t := s / TiB
 	r := s % TiB
-	return float64(t) + float64(r)/(8*(1<<40))
+	return float64(t) + float64(r)/(1<<40)
 }
 
 // Pebibytes returns the size as floating point number of pebibytes (PiB).
 func (s Size) Pebibytes() float64 {
 	p := s / PiB
 	r := s % PiB
-	return float64(p) + float64(r)/(8*(1<<50))
+	return float64(p) + float64(r)/(1<<50)
 }
 
 // Abs returns the absolute value of s. As a special case, math.MinInt64 is

--- a/size_test.go
+++ b/size_test.go
@@ -10,17 +10,15 @@ var sizeStringTests = []struct {
 	Size   Size
 	String string
 }{
-	{Size: 0, String: "0B"},                                    // 0
-	{Size: Bit, String: "0.125B"},                              // 1
-	{Size: Byte, String: "1B"},                                 // 2
-	{Size: MB, String: "1MB"},                                  // 3
-	{Size: -MB, String: "-1MB"},                                // 4
-	{Size: MiB, String: "1.048576MB"},                          // 5
-	{Size: MBit, String: "125KB"},                              // 6
-	{Size: 5*TB + 640*GB + 509*MB, String: "5.640509TB"},       // 7
-	{Size: -1*MB - 825*KB, String: "-1.825MB"},                 // 8
-	{Size: 1000*PB + Bit, String: "1000.000000000000000125PB"}, // 9
-	{Size: 1000*PB + Byte, String: "1000.000000000000001PB"},   // 10
+	{Size: 0, String: "0B"},                                  // 0
+	{Size: Byte, String: "1B"},                               // 2
+	{Size: MB, String: "1MB"},                                // 3
+	{Size: -MB, String: "-1MB"},                              // 4
+	{Size: MiB, String: "1.048576MB"},                        // 5
+	{Size: MBit, String: "125KB"},                            // 6
+	{Size: 5*TB + 640*GB + 509*MB, String: "5.640509TB"},     // 7
+	{Size: -1*MB - 825*KB, String: "-1.825MB"},               // 8
+	{Size: 1000*PB + Byte, String: "1000.000000000000001PB"}, // 10
 }
 
 func TestSize_String(t *testing.T) {
@@ -44,8 +42,6 @@ var sizeAbsTests = []struct {
 	Abs  Size
 }{
 	{Size: 0, Abs: 0},                 // 0
-	{Size: 1 * Bit, Abs: 1 * Bit},     // 1
-	{Size: -1 * Bit, Abs: 1 * Bit},    // 2
 	{Size: -1 * Byte, Abs: 1 * Byte},  // 3
 	{Size: minSize, Abs: MaxSize},     // 4
 	{Size: minSize + 1, Abs: MaxSize}, // 5
@@ -81,11 +77,6 @@ var sizeTruncateTests = []struct {
 		Size:  1*MB + 500*KB,
 		Mod:   1 * MB,
 		Trunc: 1 * MB,
-	},
-	{ // 4
-		Size:  11*KB + 7*Bit,
-		Mod:   11 * KB,
-		Trunc: 11 * KB,
 	},
 	{ // 5
 		Size:  -(12*GiB + 5*MiB + 7*Byte),
@@ -204,15 +195,6 @@ var sizeByteTests = []struct {
 	TB    float64
 	PB    float64
 }{
-	{ // 0
-		Size:  1 * Bit,
-		Bytes: 0.125,
-		KB:    0.000125,
-		MB:    0.000000125,
-		GB:    0.000000000125,
-		TB:    0.000000000000125,
-		PB:    0.000000000000000125,
-	},
 	{ // 1
 		Size:  1 * Byte,
 		Bytes: 1,
@@ -221,15 +203,6 @@ var sizeByteTests = []struct {
 		GB:    0.000000001,
 		TB:    0.000000000001,
 		PB:    0.000000000000001,
-	},
-	{ // 2
-		Size:  1*Byte + 3*Bit,
-		Bytes: 1.375,
-		KB:    0.001375,
-		MB:    0.000001375,
-		GB:    0.000000001375,
-		TB:    0.000000000001375,
-		PB:    0.000000000000001375,
 	},
 	{ // 3
 		Size:  1*KB + 172*Byte,
@@ -257,15 +230,6 @@ var sizeByteTests = []struct {
 		GB:    0.012000271,
 		TB:    0.000012000271,
 		PB:    0.000000012000271,
-	},
-	{ // 6
-		Size:  542*GB + 1*MB + 17*KB + 859*Byte + 4*Bit,
-		Bytes: 542001017859.5,
-		KB:    542001017.8595,
-		MB:    542001.0178595,
-		GB:    542.0010178595,
-		TB:    0.5420010178595,
-		PB:    0.0005420010178595,
 	},
 	{ // 7
 		Size:  117*TB + 4*KB,
@@ -326,53 +290,11 @@ var sizeBitTests = []struct {
 	GBits float64
 	TBits float64
 }{
-	{ // 0
-		Size:  1 * Bit,
-		KBits: 0.001,
-		MBits: 0.000001,
-		GBits: 0.000000001,
-		TBits: 0.000000000001,
-	},
 	{ // 1
 		Size:  1 * KBit,
 		KBits: 1,
 		MBits: 0.001,
 		GBits: 0.000001,
 		TBits: 0.000000001,
-	},
-	{ // 2
-		Size:  1*KBit + 512*Bit,
-		KBits: 1.512,
-		MBits: 0.001512,
-		GBits: 0.000001512,
-		TBits: 0.000000001512,
-	},
-	{ // 3
-		Size:  64*KBit + 375*Bit,
-		KBits: 64.375,
-		MBits: 0.064375,
-		GBits: 0.000064375,
-		TBits: 0.000000064375,
-	},
-	{ // 4
-		Size:  1*MBit + 784*KBit + 63*Bit,
-		KBits: 1784.063,
-		MBits: 1.784063,
-		GBits: 0.001784063,
-		TBits: 0.000001784063,
-	},
-	{ // 5
-		Size:  12*GBit + 632*MBit + 76*KBit + 901*Bit,
-		KBits: 12632076.901,
-		MBits: 12632.076901,
-		GBits: 12.632076901,
-		TBits: 0.012632076901,
-	},
-	{ // 6
-		Size:  402*TBit + 551*GBit + 209*MBit + 811*KBit + 4*Bit,
-		KBits: 402551209811.004,
-		MBits: 402551209.811004,
-		GBits: 402551.209811004,
-		TBits: 402.551209811004,
 	},
 }


### PR DESCRIPTION
This commit changes the `Size` type
to represent an amount of bytes instead
of an amount of bits.

The main reason for this change are buffer
allocations. It is expected that a user
can allocate a buffer with a pre-defined size/cap
easily via:
```
buffer := make([]byte, 64 * mem.KB)
```

When representing `Size` as number of bits, a user would allocate an `8 * 1000` byte buffer - since a `KB` would be 8000.
This is pitfall a user could easily fall into.

Since most Go code deals with bytes anyways we
re-define `Size` to represent the number of bytes.

For measuring sizes in bits we could add a new type, e.g. `BitSize`, anytime.

As part of this change all formatting / parsing of sizes does no longer support de/serialization to/from bits. For example, "1Mbit" is no longer a valid size.