### PR TITLE
add `LimitReader` function as wrapper around `io.LimitReader`

### DIFF
--- a/io.go
+++ b/io.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 Andreas Auernhammer. All rights reserved.
+// Use of this source code is governed by a license that can be
+// found in the LICENSE file.
+
+package mem
+
+import "io"
+
+// LimitReader returns a io.LimitedReader that reads from r
+// but stops with io.EOF after n bytes.
+func LimitReader(r io.Reader, n Size) *io.LimitedReader {
+	return &io.LimitedReader{
+		R: r,
+		N: int64(n),
+	}
+}


### PR DESCRIPTION
This commit adds a utility function `LimitReader` that wraps an io.Reader and limits it to `n` bytes.

It behaves like `io.LimitReader` but:
 1. accepts a `Size` instead of an `int64` This avoids an unnecessary manual type cast.
 2. returns a concrete type `io.LimitedReader` instead of an `io.Reader` interface